### PR TITLE
Omit params import conditionally

### DIFF
--- a/packages/cli/src/codegen/operations.ts
+++ b/packages/cli/src/codegen/operations.ts
@@ -122,7 +122,11 @@ function generateFileContent(
   const content = `import * as t from "io-ts";
   import type { RequestFunction } from "${RUNTIME_PACKAGE}";
   import * as schemas from "../${SCHEMAS_PATH}";
-  import * as parameters from "../${PARAMETERS_PATH}";
+  ${
+    operation.parameters.length > 0
+      ? `import * as parameters from "../${PARAMETERS_PATH}";`
+      : ""
+  }
   import * as responses from "../${RESPONSES_PATH}";
   import * as requestBodies from "../${REQUEST_BODIES_PATH}";
 


### PR DESCRIPTION
Building after codegen was failing because there was no parameters/index.ts; omitting the import altogether if there are no parameters available.